### PR TITLE
feat(projects): améliorer l'affichage des images avec alignement vertical en haut

### DIFF
--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -33,7 +33,7 @@ const Section: React.FC<SectionProps> = ({ title, items }) => (
 								alt={`Capture d'écran du projet ${item.title}`}
 								width={600}
 								height={400}
-								className="w-full h-64 lg:h-72 object-cover group-hover:scale-105 transition-transform duration-300"
+								className="w-full h-64 lg:h-72 object-cover object-top group-hover:scale-105 transition-transform duration-300"
 								loading="lazy"
 								placeholder="blur"
 								blurDataURL={BLUR_PLACEHOLDER_SVG}


### PR DESCRIPTION
## Résumé
- Amélioration de l'affichage des images des projets en alignant verticalement vers le haut
- Les images restent centrées horizontalement mais montrent maintenant leur partie supérieure

## Changements
- Ajout de la classe CSS `object-top` aux images des projets dans `/app/projects/page.tsx`
- Les captures d'écran des projets affichent maintenant leur partie la plus importante (généralement en haut)

## Technique
**Avant :**
```css
object-cover
```

**Après :**
```css
object-cover object-top
```

## Impact
✅ **Amélioration visuelle :** Les parties importantes des captures d'écran sont maintenant visibles
✅ **Compatibilité :** Aucun impact sur la responsivité, les performances ou les effets hover
✅ **Maintenance :** Changement minimal et rétrocompatible

## Test
- ✅ Build réussi sans erreurs
- ✅ TypeScript compilation OK
- ✅ Effets hover et transitions préservés
- ✅ Responsive design maintenu